### PR TITLE
updated body to be non-nil unless erroring

### DIFF
--- a/mapper_test.go
+++ b/mapper_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -38,7 +39,8 @@ func TestBasicMap(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Nil(t, resp.Body)
+	assert.NotNil(t, resp.Body)
+	assert.Equal(t, ioutil.NopCloser(bytes.NewBuffer(nil)), resp.Body)
 }
 
 func TestMapNonJSON(t *testing.T) {

--- a/response.go
+++ b/response.go
@@ -38,9 +38,7 @@ func (r *response) HTTPResponse() (*http.Response, error) {
 	resp := &http.Response{
 		StatusCode: r.StatusCode,
 	}
-	if body != nil {
-		resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-	}
+	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 	return resp, nil
 }


### PR DESCRIPTION
According to go spec: the response body will only ever be nil if there was an error during transport.